### PR TITLE
Check if reboot required

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ sudo apt upgrade -y
 sudo apt install -y git
 ```
 
+> Note: if the `sudo apt upgrade` command resulted in the kernel being updated then you should reboot the system before proceeding.
+
 ### Initial Setup (Ubuntu 22.04 LTS "jammy")
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### This project was [originally] focused on the steps needed to build, install, and configure an AllStarLink node running on a virtual machine [VM] in the cloud.
 
-### That focus has not precluded efforts to manage other deployments (e.g. a DELL Wyse 3040 and Raspberry Pi running Debian).
+### That focus has not precluded efforts to support other deployments (e.g. a DELL Wyse 3040 and Raspberry Pi running Debian).
 
 ## Target Operating System(s)
 


### PR DESCRIPTION
We run into issues when an OS update/upgrade installs a new kernel but the system has not yet been rebooted.  This is because DAHDI is built with the linux-headers for the currently running kernel vs. the headers for the kernel that will be
used after the reboot.  To avoid this conflict we add a check to see if there is a difference between the running and last/recently installed kernel differ. If so, we suggest a reboot.